### PR TITLE
fix: 增加对拾光课程表（Dev）的支持

### DIFF
--- a/app/src/main/java/com/xiaoai/islandnotify/MainActivity.java
+++ b/app/src/main/java/com/xiaoai/islandnotify/MainActivity.java
@@ -48,6 +48,7 @@ public class MainActivity extends AppCompatActivity {
     private static final String TARGET_VOICEASSIST = "com.miui.voiceassist";
     private static final String TARGET_WAKEUP = "com.suda.yzune.wakeupschedule";
     private static final String TARGET_SHIGUANG = "com.xingheyuzhuan.shiguangschedule";
+    private static final String TARGET_SHIGUANG_DEV = "com.xingheyuzhuan.shiguangschedule.dev";
     private static final String TARGET_DESKCLOCK = "com.android.deskclock";
     private static final String TARGET_SYSTEMUI = "com.android.systemui";
     private static final String TARGET_SYSTEMUI_PLUGIN = "miui.systemui.plugin";
@@ -204,10 +205,26 @@ public class MainActivity extends AppCompatActivity {
             return;
         }
         if ("shiguang".equalsIgnoreCase(source)) {
+            if (hasAnyShiguangScope()) {
+                if (onApproved != null) onApproved.run();
+                return;
+            }
             ensureScopeForTarget(TARGET_SHIGUANG, onApproved);
             return;
         }
         if (onApproved != null) onApproved.run();
+    }
+
+    private boolean hasAnyShiguangScope() {
+        XposedService service = IslandNotifyApp.currentService();
+        if (service == null) return false;
+        try {
+            Set<String> current = new HashSet<>(service.getScope());
+            return current.contains(TARGET_SHIGUANG) || current.contains(TARGET_SHIGUANG_DEV);
+        } catch (Throwable t) {
+            Log.w("IslandNotify", "hasAnyShiguangScope failed: " + t.getMessage());
+            return false;
+        }
     }
 
     void uiEnsureScopeForWakeupEnable(Runnable onApproved) {

--- a/app/src/main/java/com/xiaoai/islandnotify/hook/MainHook.java
+++ b/app/src/main/java/com/xiaoai/islandnotify/hook/MainHook.java
@@ -108,6 +108,7 @@ public class MainHook {
     /** 拾光镜像存储键（写入 voiceassist 自身独立 SP） */
     private static final String KEY_SHIGUANG_MIRROR_BEAN = "shiguang_mirror_week_course_bean";
     private static final String KEY_SHIGUANG_MIRROR_HASH = "shiguang_mirror_week_course_hash";
+    private static final String KEY_SHIGUANG_MIRROR_PACKAGE = "shiguang_mirror_package";
     /** 课前提醒分钟数配置键（存入 island_custom SP） */
     private static final String KEY_REMINDER_MINUTES = "reminder_minutes_before";
     /** 课前提醒默认提前分钟数 */
@@ -806,9 +807,11 @@ public class MainHook {
             int oldHash = mirror.getInt(KEY_SHIGUANG_MIRROR_HASH, 0);
             if (hash == oldHash) return true;
             boolean isFirstSync = (oldHash == 0);
+            String sourcePackage = safeStr(intent.getStringExtra("source_package"));
             mirror.edit()
                     .putString(KEY_SHIGUANG_MIRROR_BEAN, beanJson)
                     .putInt(KEY_SHIGUANG_MIRROR_HASH, hash)
+                    .putString(KEY_SHIGUANG_MIRROR_PACKAGE, sourcePackage)
                     .apply();
             SharedPreferences prefs = getConfigPrefs(context);
             if (isShiguangDataSource(prefs)) {
@@ -2059,7 +2062,15 @@ public class MainHook {
         if (SOURCE_WAKEUP.equalsIgnoreCase(source)) {
             launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_WAKEUP);
         } else if (SOURCE_SHIGUANG.equalsIgnoreCase(source)) {
-            launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG);
+            String sourcePackage = readShiguangMirrorPackage(ctx);
+            if (PKG_SHIGUANG_DEV.equals(sourcePackage)) {
+                launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG_DEV);
+            } else if (PKG_SHIGUANG.equals(sourcePackage)) {
+                launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG);
+            }
+            if (launchIntent == null) {
+                launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG);
+            }
             if (launchIntent == null) {
                 launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG_DEV);
             }
@@ -2605,6 +2616,16 @@ public class MainHook {
             SharedPreferences mirror =
                     ctx.getSharedPreferences(PREFS_SHIGUANG_MIRROR, Context.MODE_PRIVATE);
             return mirror.getString(KEY_SHIGUANG_MIRROR_BEAN, null);
+        } catch (Throwable ignored) {
+            return null;
+        }
+    }
+
+    private String readShiguangMirrorPackage(Context ctx) {
+        try {
+            SharedPreferences mirror =
+                    ctx.getSharedPreferences(PREFS_SHIGUANG_MIRROR, Context.MODE_PRIVATE);
+            return mirror.getString(KEY_SHIGUANG_MIRROR_PACKAGE, null);
         } catch (Throwable ignored) {
             return null;
         }

--- a/app/src/main/java/com/xiaoai/islandnotify/hook/MainHook.java
+++ b/app/src/main/java/com/xiaoai/islandnotify/hook/MainHook.java
@@ -99,6 +99,7 @@ public class MainHook {
     private static final String PKG_WAKEUP = "com.suda.yzune.wakeupschedule";
     /** 拾光包名（作为通知点击目标） */
     private static final String PKG_SHIGUANG = "com.xingheyuzhuan.shiguangschedule";
+    private static final String PKG_SHIGUANG_DEV = "com.xingheyuzhuan.shiguangschedule.dev";
     /** 配置项：课程数据源 */
     private static final String KEY_COURSE_DATA_SOURCE = "course_data_source";
     /** WakeUp 镜像存储键（写入 voiceassist 自身 island_runtime） */
@@ -2059,6 +2060,9 @@ public class MainHook {
             launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_WAKEUP);
         } else if (SOURCE_SHIGUANG.equalsIgnoreCase(source)) {
             launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG);
+            if (launchIntent == null) {
+                launchIntent = ctx.getPackageManager().getLaunchIntentForPackage(PKG_SHIGUANG_DEV);
+            }
         }
         if (launchIntent != null) {
             launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);

--- a/app/src/main/java/com/xiaoai/islandnotify/hook/ShiguangHook.java
+++ b/app/src/main/java/com/xiaoai/islandnotify/hook/ShiguangHook.java
@@ -50,14 +50,16 @@ public class ShiguangHook {
     private android.os.Handler mHandler;
     private final Object mSyncToken = new Object();
     private volatile int mLastPushedHash = 0;
+    private volatile String mSourcePackageName = TARGET_PACKAGE;
 
     public void handleLoadPackage(String packageName, String processName, ClassLoader classLoader) {
         if (!isTargetPackage(packageName)) return;
         if (!isTargetPackage(processName)) return;
         if (System.getProperty(HOOKED_KEY) != null) return;
         System.setProperty(HOOKED_KEY, "1");
+        mSourcePackageName = packageName;
         hookApplicationOnCreate(classLoader);
-        XposedBridge.log(TAG + ": 已注入目标进程 → " + TARGET_PACKAGE);
+        XposedBridge.log(TAG + ": 已注入目标进程 → " + packageName);
     }
 
     private static boolean isTargetPackage(String packageName) {
@@ -156,6 +158,7 @@ public class ShiguangHook {
             sync.addFlags(Intent.FLAG_INCLUDE_STOPPED_PACKAGES | Intent.FLAG_RECEIVER_FOREGROUND);
             sync.putExtra("bean_json", beanJson);
             sync.putExtra("hash", hash);
+            sync.putExtra("source_package", mSourcePackageName);
             ctx.sendBroadcast(sync);
             XposedBridge.log(TAG + ": 已推送拾光课程镜像 -> voiceassist reason=" + reason + " hash=" + hash);
         } catch (Throwable t) {

--- a/app/src/main/java/com/xiaoai/islandnotify/hook/ShiguangHook.java
+++ b/app/src/main/java/com/xiaoai/islandnotify/hook/ShiguangHook.java
@@ -37,6 +37,7 @@ public class ShiguangHook {
 
     private static final String TAG = "IslandNotifyShiguang";
     private static final String TARGET_PACKAGE = "com.xingheyuzhuan.shiguangschedule";
+    private static final String TARGET_PACKAGE_DEV = "com.xingheyuzhuan.shiguangschedule.dev";
     private static final String TARGET_VOICEASSIST = "com.miui.voiceassist";
     private static final String DB_NAME = "main_app_database";
     private static final String DATASTORE_NAME = "app_settings.preferences_pb";
@@ -51,12 +52,16 @@ public class ShiguangHook {
     private volatile int mLastPushedHash = 0;
 
     public void handleLoadPackage(String packageName, String processName, ClassLoader classLoader) {
-        if (!TARGET_PACKAGE.equals(packageName)) return;
-        if (!TARGET_PACKAGE.equals(processName)) return;
+        if (!isTargetPackage(packageName)) return;
+        if (!isTargetPackage(processName)) return;
         if (System.getProperty(HOOKED_KEY) != null) return;
         System.setProperty(HOOKED_KEY, "1");
         hookApplicationOnCreate(classLoader);
         XposedBridge.log(TAG + ": 已注入目标进程 → " + TARGET_PACKAGE);
+    }
+
+    private static boolean isTargetPackage(String packageName) {
+        return TARGET_PACKAGE.equals(packageName) || TARGET_PACKAGE_DEV.equals(packageName);
     }
 
     private void hookApplicationOnCreate(ClassLoader classLoader) {

--- a/app/src/main/resources/META-INF/xposed/scope.list
+++ b/app/src/main/resources/META-INF/xposed/scope.list
@@ -4,3 +4,4 @@ com.android.systemui
 miui.systemui.plugin
 com.suda.yzune.wakeupschedule
 com.xingheyuzhuan.shiguangschedule
+com.xingheyuzhuan.shiguangschedule.dev


### PR DESCRIPTION
只增加相关作用域及 UI 判断。
考虑到拾光课程表开发者版本用途特殊，故请求作用域仍使用原有逻辑不变（只请求正式版包名），可在 LSPosed 管理器手动勾选 Dev 版。